### PR TITLE
Match skill descriptions

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -68,7 +68,7 @@ class User < ApplicationRecord
   end
 
   def skills_competencies
-    competencies = ["Only a little knowledge", "Gaining competency", "Individual competency", "Strong competency", "Expert"]
+    competencies = ["Familiarity", "Gaining Competency", "Individual Competency", "Strong Competency", "Leadership"]
     num_hash = return_skills_hash
     new_hash = {}
     num_hash.each { |language, skill| new_hash[language] = competencies[skill -1] }

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -63,7 +63,7 @@ class User < ApplicationRecord
   end
 
   def competency_description(selection)
-    competencies = ["Only a little knowledge", "Gaining competency", "Individual competency", "Strong competency", "Expert"]
+    competencies = ["Familiarity", "Gaining Competency", "Individual Competency", "Strong Competency", "Leadership"]
     return competencies[selection]
   end
 

--- a/app/views/dashboard/index.html.erb
+++ b/app/views/dashboard/index.html.erb
@@ -9,7 +9,7 @@
 
         <div class="col-xs-12 col-sm-8 col-md-8 justify-content-center align-self-center">
           <h2 class="centered dashboard-home small-padded-text">Your Dashboard</h2>
-          <p class="centered">Here you can find all your matches, including the one you applied to and your saved jobs.</p>
+          <p class="centered">Here you can find all your matched opportunities, roles you've favorited, and live applications you've submitted.</p>
         </div>
       </div>
     </div>

--- a/app/views/users/edit_skills.html.erb
+++ b/app/views/users/edit_skills.html.erb
@@ -37,7 +37,7 @@
                 <input class="form-check-input" data-lang="<%= hash[0] %>" data-form-id='<%= index %>' type="radio" name="skills-<%= index %>" value="<%=hash[0]%>4" >
 
                 <label class="form-check-label">
-                  <p>Strong <i>(5+ years of professional experience, could mentor others)</i></p>
+                  <p>Strong Competency <i>(5+ years of professional experience, could mentor others)</i></p>
                 </label>
               </div>
               <div class="form-check">
@@ -141,7 +141,7 @@
 
 
     const summary = document.querySelector('#summarized-form');
-    const skills = ["Only a little knowledge", "Gaining competency", "Individual competency", "Strong competency", "Expert"]
+    const skills = ["Familiarity", "Gaining Competency", "Individual Competency", "Strong Competency", "Leadership"]
 
 
     function fillSummary(input) {

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -3,7 +3,7 @@
   <div class="profile-header">
    <div class="row justify-content-center ">
     <div class="col-xs-12 col-sm-4 col-md-4 justify-content-center align-self-center">
-        <%= cl_image_tag current_user.photo, height: 200, width: 200, crop: :fill, :radius => :max, :gravity => :face %>
+      <%= cl_image_tag current_user.photo, height: 200, width: 200, crop: :fill, :radius => :max, :gravity => :face %>
     </div>
 
     <div class="col-xs-12 col-sm-8 col-md-8 justify-content-center align-self-center">
@@ -12,9 +12,11 @@
         <br>
         <p class="centered">Your job search is:</p>
         <h5 class="centered"> <em><%= current_user.return_activation_status %></em></h5>
+        <% if !current_user.location_list.empty? %>
         <br>
         <p class="centered">You are looking for jobs in:</p>
         <h5 class="centered"> <em><%= current_user.location_list %></em></h5>
+        <% end %>
       </div>
     </div>
   </div>

--- a/app/views/users/skills.erb
+++ b/app/views/users/skills.erb
@@ -7,35 +7,35 @@ skills form
               <input class="form-check-input" type="radio" name="skills-<%= index %>" value="<%=hash[0]%>1" checked>
 
               <label class="form-check-label">
-                Only a little knowledge
+                Familiarity
               </label>
             </div>
             <div class="form-check">
               <input class="form-check-input" type="radio" name="skills-<%= index %>" value="<%=hash[0]%>2">
 
               <label class="form-check-label">
-                Gaining competency
+                Gaining Competency
               </label>
             </div>
             <div class="form-check">
               <input class="form-check-input" type="radio" name="skills-<%= index %>" value="<%=hash[0]%>3" >
 
               <label class="form-check-label">
-                Individual competency
+                Individual Competency
               </label>
             </div>
             <div class="form-check">
               <input class="form-check-input" type="radio" name="skills-<%= index %>" value="<%=hash[0]%>4" >
 
               <label class="form-check-label">
-                Strong competency
+                Strong Competency
               </label>
             </div>
             <div class="form-check">
               <input class="form-check-input" type="radio" name="skills-<%= index %>" value="<%=hash[0]%>5" >
 
               <label class="form-check-label">
-                Expert
+                Leadership
               </label>
             </div>
 


### PR DESCRIPTION
Changing "skill descriptions" so they are consistent everywhere. 
Also editing a minor grammar error and making "you are looking for jobs in:" disappear if you have no locations selected. 