### PR TITLE
Mailchimp

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -27,6 +27,7 @@ gem 'omniauth-linkedin'
 gem 'pry-byebug'
 gem 'pry-rails'
 gem 'pdf-reader'
+gem 'gibbon'
 
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -101,6 +101,8 @@ GEM
     execjs (2.7.0)
     faker (1.8.7)
       i18n (>= 0.7)
+    faraday (0.14.0)
+      multipart-post (>= 1.2, < 3)
     ffi (1.9.23)
     figaro (1.1.1)
       thor (~> 0.14)
@@ -109,6 +111,9 @@ GEM
     formtastic (3.1.5)
       actionpack (>= 3.2.13)
     formtastic_i18n (0.6.0)
+    gibbon (3.2.0)
+      faraday (>= 0.9.1)
+      multi_json (>= 1.11.0)
     globalid (0.4.1)
       activesupport (>= 4.2.0)
     has_scope (0.7.1)
@@ -160,6 +165,7 @@ GEM
     mini_portile2 (2.3.0)
     minitest (5.11.3)
     multi_json (1.13.1)
+    multipart-post (2.0.0)
     netrc (0.11.0)
     nio4r (2.2.0)
     nokogiri (1.8.2)
@@ -305,6 +311,7 @@ DEPENDENCIES
   faker
   figaro
   font-awesome-sass
+  gibbon
   jbuilder (~> 2.0)
   jquery-rails
   listen (~> 3.0.5)

--- a/app/controllers/registrations_controller.rb
+++ b/app/controllers/registrations_controller.rb
@@ -1,5 +1,3 @@
-require 'gibbon'
-
 class RegistrationsController < Devise::RegistrationsController
 
   def create

--- a/app/controllers/registrations_controller.rb
+++ b/app/controllers/registrations_controller.rb
@@ -1,9 +1,22 @@
+require 'gibbon'
+
 class RegistrationsController < Devise::RegistrationsController
 
   def create
     super do
       User.create(registration_id: resource.id)
+      subscribe_to_mailchimp
     end
+  end
+
+  def subscribe_to_mailchimp
+    binding.pry
+    gibbon = Gibbon::Request.new(api_key: ENV['MAILCHIMP_API_KEY'])
+    gibbon.timeout = 15
+    gibbon.open_timeout = 15
+    gibbon.symbolize_keys = true
+    gibbon.debug = false
+    gibbon.lists(ENV['MAILCHIMP_LIST_ID']).members.create(body: {email_address: resource.email, status: "subscribed"})
   end
 
   protected

--- a/app/controllers/registrations_controller.rb
+++ b/app/controllers/registrations_controller.rb
@@ -10,13 +10,12 @@ class RegistrationsController < Devise::RegistrationsController
   end
 
   def subscribe_to_mailchimp
-    binding.pry
     gibbon = Gibbon::Request.new(api_key: ENV['MAILCHIMP_API_KEY'])
     gibbon.timeout = 15
     gibbon.open_timeout = 15
     gibbon.symbolize_keys = true
     gibbon.debug = false
-    gibbon.lists(ENV['MAILCHIMP_LIST_ID']).members.create(body: {email_address: resource.email, status: "subscribed"})
+    gibbon.lists(ENV['MAILCHIMP_LIST_ID']).members(Digest::MD5.hexdigest(resource.email)).upsert(body: {email_address: resource.email, status: "subscribed"})
   end
 
   protected

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -22,7 +22,6 @@ class UsersController < ApplicationController
   end
 
   def update_mailchimp
-    binding.pry
     gibbon = Gibbon::Request.new(api_key: ENV['MAILCHIMP_API_KEY'])
     gibbon.timeout = 15
     gibbon.open_timeout = 15

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -15,9 +15,20 @@ class UsersController < ApplicationController
   def update
     if @user.update(user_params)
       @user.add_tags(params[:tags])
+      update_mailchimp
       redirect_to edit_skills_user_path(@user)
     else
     end
+  end
+
+  def update_mailchimp
+    binding.pry
+    gibbon = Gibbon::Request.new(api_key: ENV['MAILCHIMP_API_KEY'])
+    gibbon.timeout = 15
+    gibbon.open_timeout = 15
+    gibbon.symbolize_keys = true
+    gibbon.debug = false
+    gibbon.lists(ENV['MAILCHIMP_LIST_ID']).members(Digest::MD5.hexdigest(@user.registration.email)).upsert(body: {email_address: @user.registration.email, status: "subscribed", merge_fields: {FNAME: @user.first_name, LNAME: @user.last_name}})
   end
 
   def activate

--- a/config/initializers/gibbon.rb
+++ b/config/initializers/gibbon.rb
@@ -1,7 +1,0 @@
-require 'gibbon'
-
-gibbon = Gibbon::Request.new(api_key: ENV['MAILCHIMP_API_KEY'])
-gibbon.timeout = 15
-gibbon.open_timeout = 15
-gibbon.symbolize_keys = true
-gibbon.debug = false

--- a/config/initializers/gibbon.rb
+++ b/config/initializers/gibbon.rb
@@ -1,0 +1,5 @@
+Gibbon::Request.new(api_key: ENV['MAILCHIMP_API_KEY'])
+Gibbon::Request.timeout = 15
+Gibbon::Request.open_timeout = 15
+Gibbon::Request.symbolize_keys = true
+Gibbon::Request.debug = false

--- a/config/initializers/gibbon.rb
+++ b/config/initializers/gibbon.rb
@@ -1,0 +1,7 @@
+require 'gibbon'
+
+gibbon = Gibbon::Request.new(api_key: ENV['MAILCHIMP_API_KEY'])
+gibbon.timeout = 15
+gibbon.open_timeout = 15
+gibbon.symbolize_keys = true
+gibbon.debug = false

--- a/test/workers/hard_worker_test.rb
+++ b/test/workers/hard_worker_test.rb
@@ -1,0 +1,6 @@
+require 'test_helper'
+class HardWorkerTest < MiniTest::Unit::TestCase
+  def test_example
+    skip "add some examples to (or delete) #{__FILE__}"
+  end
+end


### PR DESCRIPTION
Users are now automatically subscribed to Mailchimp when they sign up, and their name is updated when they create a profile. 

I went down a rabbit hole of trying to call both of these asynchronously from a 'job' file, but in the end realized it would take several more hours and that was find for a later day. All that code should be deleted. 

Will be hard for anyone to 'test' that this is working without the Mailchimp login, but maybe just test that it doesn't crash your computer? 