### PR TITLE
Log in page reorganization

### DIFF
--- a/app/assets/stylesheets/components/_background.scss
+++ b/app/assets/stylesheets/components/_background.scss
@@ -1,5 +1,5 @@
 body {
-  min-height: 80vh;
+  min-height: 90vh;
   position: relative;
 }
 

--- a/app/assets/stylesheets/components/_button.scss
+++ b/app/assets/stylesheets/components/_button.scss
@@ -61,13 +61,13 @@
 
   .btn-orange {
   padding: 10px 15px;
+  margin: 1vh;
   border: 1px solid $light-orange;
   transition: 0.1s background-color ease-in-out;
   text-decoration: none;
   color: white;
   letter-spacing: 5px;
   background-color: $light-orange;
-  transition: 0.5s padding ease-in-out;
   font-weight: 900;
   font-family: "Montserrat", "sans-serif";
   font-size: 15px;
@@ -75,7 +75,6 @@
 }
 
 .btn-orange:hover {
-  padding: 10px 50px;
   background-color: $light-orange;
   border: 1px solid $light-orange;
   text-decoration: none;

--- a/app/assets/stylesheets/pages/_registration.scss
+++ b/app/assets/stylesheets/pages/_registration.scss
@@ -1,12 +1,37 @@
 .login-form {
   padding-left: 15%;
   padding-right: 15%;
-  padding-bottom: 7vh;
+  padding-bottom: 2vh;
+  padding-top: 2vh;
+  border: 1px solid #f0f0f0;
+  background-color: white;
+  margin-top: 3vh;
+}
+
+.login-form-bottom {
+  padding-left: 15%;
+  padding-right: 15%;
+  padding-bottom: 2vh;
+  padding-top: 2vh;
+  border: 1px solid #f0f0f0;
+  background-color: #3c3b3a;
+  color: #b7b7b7;
+  font-size: 15px;
+  line-height: 2;
+
+  a {
+    font-family: Lora;
+    color: #42a8b7
+  }
 }
 
 .inside-login-form {
   padding-left: 15%;
   padding-right: 15%;
+}
+
+.small-text {
+  font-size: 14px
 }
 
 @media (max-width: 800px) {
@@ -19,8 +44,32 @@
 .log-in-button {
   margin-bottom: 5vh;
   margin-top: 5vh;
+  margin-right: 4vh;
+}
+
+//////
+
+.registration-grid {
+  border: 1px solid #f0f0f0;
+  padding: 21px 25px;
+  background-color: white;
+  margin-top: 2vh;
+
+}
+
+.inline {
+  display: inline-block;
 }
 
 .forgot-password {
-    height: 70vh
-  }
+  font-family: 'Lora', serif;
+  color: #42a8b7;
+
+}
+
+.login-title {
+   margin-top: 4vh;
+  margin-bottom: 4vh;
+
+}
+

--- a/app/assets/stylesheets/pages/_registration.scss
+++ b/app/assets/stylesheets/pages/_registration.scss
@@ -18,6 +18,7 @@
   color: #b7b7b7;
   font-size: 15px;
   line-height: 2;
+  margin-bottom: 3vh;
 
   a {
     font-family: Lora;
@@ -42,9 +43,9 @@
 }
 
 .log-in-button {
-  margin-bottom: 5vh;
-  margin-top: 5vh;
-  margin-right: 4vh;
+  margin-bottom: 3vh;
+  margin-top: 3vh;
+  margin-right: 3vh;
 }
 
 //////
@@ -73,3 +74,6 @@
 
 }
 
+.help-block {
+  font-size: 13px;
+}

--- a/app/views/devise/passwords/new.html.erb
+++ b/app/views/devise/passwords/new.html.erb
@@ -1,20 +1,21 @@
-<div class="login-form forgot-password">
-  <h1 class="centered padded-title home-title">Forgot your password?</h2>
+<div class="row justify-content-center">
+  <div class="col-xs-11 col-sm-11 col-md-8">
 
-<div class="inside-login-form">
-<%= simple_form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :post }) do |f| %>
+    <div class="login-form">
+
+      <h4 class="centered login-title">Forgot your password?</h4>
+        <%= simple_form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :post }) do |f| %>
   <%= f.error_notification %>
+    <%= f.input :email, required: true, autofocus: true, label: 'Enter your email address:', placeholder: 'Email' %>
 
-  <div class="form-inputs">
-    <%= f.input :email, required: true, autofocus: true %>
+    <div class="centered">
+    <%= f.button :submit, "Reset my Password", class: "btn-orange log-in-button centered" %>
   </div>
+    <% end %>
 
-  <div class="login-form-bot centered">
-  <div class="form-actions log-in-button">
-    <%= f.button :submit, "Reset my Password", class: "btn-orange" %>
   </div>
-<% end %>
 </div>
-</div>
-</div>
+
+
+
 

--- a/app/views/devise/passwords/new.html.erb
+++ b/app/views/devise/passwords/new.html.erb
@@ -7,6 +7,7 @@
         <%= simple_form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :post }) do |f| %>
   <%= f.error_notification %>
     <%= f.input :email, required: true, autofocus: true, label: 'Enter your email address:', placeholder: 'Email' %>
+    <div class="small-text">You will receive an email with a link to reset your password. <br> If you don't see the email, check your spam folder.</div>
 
     <div class="centered">
     <%= f.button :submit, "Reset my Password", class: "btn-orange log-in-button centered" %>

--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -1,27 +1,35 @@
-<h2>Edit <%= resource_name.to_s.humanize %></h2>
+<div class="row justify-content-center">
+  <div class="col-xs-11 col-sm-11 col-md-8">
 
-<%= simple_form_for(resource, as: resource_name, url: registration_path(resource_name), html: { method: :put }) do |f| %>
-  <%= f.error_notification %>
+    <div class="login-form">
 
-  <div class="form-inputs">
-    <%= f.input :email, required: true, autofocus: true %>
+      <h4 class="centered login-title">Edit your email and password</h4>
+      <%= simple_form_for(resource, as: resource_name, url: registration_path(resource_name), html: { method: :put }) do |f| %>
+      <%= f.error_notification %>
 
-    <% if devise_mapping.confirmable? && resource.pending_reconfirmation? %>
-      <p>Currently waiting confirmation for: <%= resource.unconfirmed_email %></p>
-    <% end %>
+        <%= f.input :email, required: true, autofocus: true, label: false, placeholder: 'Email', hint: 'Enter a new email address if you want to update it.' %>
 
-    <%= f.input :password, autocomplete: "off", hint: "leave it blank if you don't want to change it", required: false %>
-    <%= f.input :password_confirmation, required: false %>
-    <%= f.input :current_password, hint: "we need your current password to confirm your changes", required: true %>
+        <% if devise_mapping.confirmable? && resource.pending_reconfirmation? %>
+          <p>Currently waiting confirmation for: <%= resource.unconfirmed_email %></p>
+        <% end %>
+
+        <%= f.input :current_password, hint: "Enter your current password to confirm the changes", required: true %>
+        <%= f.input :password, autocomplete: "off", hint: "Leave this field blank if you don't want to change it.", required: false, label: false, placeholder: 'New password' %>
+        <%= f.input :password_confirmation, required: false, label: false, placeholder: 'New password confirmation' %>
+
+
+        <%= f.button :submit, "Update", class: "btn-orange log-in-button" %>
+      <% end %>
+    </div>
+
+      <div class="login-form-bottom">
+        <div>
+Unhappy? <%= link_to "Cancel my account »", registration_path(resource_name), data: { confirm: "Are you sure? This action will permanently remove your account from our database, and you won't receive amazing job offers anymore." }, method: :delete %> <br>
+Changed your mind? <%= link_to "Back to the previous page »", :back %>
+
+        </div>
+      </div>
+
   </div>
+</div>
 
-  <div class="form-actions">
-    <%= f.button :submit, "Update" %>
-  </div>
-<% end %>
-
-<h3>Cancel my account</h3>
-
-<p>Unhappy? <%= link_to "Cancel my account", registration_path(resource_name), data: { confirm: "Are you sure?" }, method: :delete %></p>
-
-<%= link_to "Back", :back %>

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -1,29 +1,33 @@
-<div class="login-form">
-<h1 class="centered padded-title home-title">Sign up</h2>
+<div class="row justify-content-center">
+  <div class="col-xs-11 col-sm-11 col-md-8">
 
-<div class="form-border">
-  <div class="inside-login-form">
-<%= simple_form_for(resource, as: resource_name, url: registration_path(resource_name)) do |f| %>
-  <%= f.error_notification %>
+    <div class="login-form">
 
-  <div class="form-inputs">
-    <%= f.input :email, required: true, autofocus: true %>
-    <%= f.input :password, required: true, hint: ("#{@minimum_password_length} characters minimum" if @minimum_password_length) %>
-    <%= f.input :password_confirmation, required: true %>
-    <%= f.input :gets_mail, :label => 'Receive occasional emails about user-bonuses and updates to our service', :input_html => { :checked => true }, :label_html => { :class => 'small-text' } %>
+      <h4 class="centered login-title">Create your account</h4>
+        <%= simple_form_for(resource, as: resource_name, url: registration_path(resource_name)) do |f| %>
+          <%= f.error_notification %>
+
+          <%= f.input :email, required: true, autofocus: true, label: false, placeholder: 'Email' %>
+          <%= f.input :password, required: true, hint: ("#{@minimum_password_length} characters minimum" if @minimum_password_length), label: false, placeholder: 'Password' %>
+          <%= f.input :password_confirmation, required: true, label: false, placeholder: 'Password confirmation' %>
+
+          <%= f.button :submit, "Sign up", class: "btn-orange log-in-button" %>
+
+          <div class="inline">
+            <%= f.input :gets_mail, :label => 'Receive occasional emails about user-bonuses and updates to our service', :input_html => { :checked => true }, :label_html => { :class => 'small-text' } %>
+          </div>
+
+        <% end %>
+
+      </div>
+
+      <div class="login-form-bottom">
+        <div>
+          <%= render "devise/shared/links" %>
+        </div>
+      </div>
+
   </div>
 </div>
-<div class="login-form-bot centered registration-button">
-  <div class="form-actions">
-    <%= f.button :submit, "Sign up", class: "btn-orange"%>
-  </div>
-<% end %>
-</div>
 
-<div class="centered">
-      <%= render "devise/shared/links" %>
-    </div>
-</div>
-</div>
-</div>
 

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -10,7 +10,7 @@
     <%= f.input :email, required: true, autofocus: true %>
     <%= f.input :password, required: true, hint: ("#{@minimum_password_length} characters minimum" if @minimum_password_length) %>
     <%= f.input :password_confirmation, required: true %>
-    <%= f.input :gets_mail, :label => 'Receive occasional emails about user-bonuses and updates to our service', :input_html => { :checked => true } %>
+    <%= f.input :gets_mail, :label => 'Receive occasional emails about user-bonuses and updates to our service', :input_html => { :checked => true }, :label_html => { :class => 'small-text' } %>
   </div>
 </div>
 <div class="login-form-bot centered registration-button">

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -4,13 +4,13 @@
     <div class="login-form">
 
       <h4 class="centered login-title">Create your account</h4>
-        <%= simple_form_for(resource, as: resource_name, url: registration_path(resource_name)) do |f| %>
-          <%= f.error_notification %>
+
+       <%= simple_form_for(resource, as: resource_name, url: registration_path(resource_name)) do |f| %>
+        <%= f.error_notification %>
 
           <%= f.input :email, required: true, autofocus: true, label: false, placeholder: 'Email' %>
           <%= f.input :password, required: true, hint: ("#{@minimum_password_length} characters minimum" if @minimum_password_length), label: false, placeholder: 'Password' %>
           <%= f.input :password_confirmation, required: true, label: false, placeholder: 'Password confirmation' %>
-
           <%= f.button :submit, "Sign up", class: "btn-orange log-in-button" %>
 
           <div class="inline">
@@ -29,5 +29,3 @@
 
   </div>
 </div>
-
-

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -1,24 +1,36 @@
-<div class="login-form">
-  <h1 class="centered padded-title home-title">Log in</h2>
+<div class="row justify-content-center">
+  <div class="col-xs-11 col-sm-11 col-md-8">
 
-<div class="form-border">
-<div class="inside-login-form">
-  <%= simple_form_for(resource, as: resource_name, url: session_path(resource_name)) do |f| %>
-  <div class="form-inputs">
-    <%= f.input :email, required: false, autofocus: true %>
-    <%= f.input :password, required: false %>
-    <%= f.input :remember_me, as: :boolean if devise_mapping.rememberable? %>
-  </div>
-  </div>
-  <div class="login-form-bot centered">
-    <div class="form-actions log-in-button">
-      <%= f.button :submit, "Log in", class: "btn-orange"%>
-    </div>
-    <% end %>
-  </div>
+    <div class="login-form">
 
-    <div class="centered">
-      <%= render "devise/shared/links" %>
-    </div>
+      <h4 class="centered login-title">Log in to your account</h4>
+        <%= simple_form_for(resource, as: resource_name, url: session_path(resource_name)) do |f| %>
+
+          <%= f.input :email, label: false, required: false, autofocus: true, placeholder: 'Email' %>
+          <%= f.input :password, label: false, required: false, placeholder: 'Password' %>
+          <%= f.button :submit, "Log in", class: "btn-orange log-in-button" %>
+
+          <div class="inline">
+            <%= f.input :remember_me,  :label_html => { :class => 'small-text' }, as: :boolean if devise_mapping.rememberable? %>
+          </div>
+          ·
+          <div class="inline">
+            <%- if devise_mapping.recoverable? && controller_name != 'passwords' && controller_name != 'registrations' %>
+              <%= link_to "Forgot your password?", new_password_path(resource_name), class: "small-text forgot-password"  %><br />
+            <% end %>
+          </div>
+
+        <% end %>
+
+      </div>
+
+      <div class="login-form-bottom">
+
+        <div>
+          <%= render "devise/shared/links" %>
+        </div>
+      </div>
+
+  </div>
 </div>
-</div>
+

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -13,6 +13,7 @@
           <div class="inline">
             <%= f.input :remember_me,  :label_html => { :class => 'small-text' }, as: :boolean if devise_mapping.rememberable? %>
           </div>
+
           ·
           <div class="inline">
             <%- if devise_mapping.recoverable? && controller_name != 'passwords' && controller_name != 'registrations' %>
@@ -25,7 +26,6 @@
       </div>
 
       <div class="login-form-bottom">
-
         <div>
           <%= render "devise/shared/links" %>
         </div>

--- a/app/views/devise/shared/_links.html.erb
+++ b/app/views/devise/shared/_links.html.erb
@@ -3,10 +3,9 @@
     Do you already have an account? <%= link_to "Log in now »", new_session_path(resource_name)  %><br>
     <% end -%>
 
-    <%- if controller_name = 'sessions' %>
+    <%- if controller_name != 'registrations' %>
     New to Find My Flock? <%= link_to "Sign up now »", new_registration_registration_path  %><br>
     <% end -%>
-
 
 
 <%- if devise_mapping.omniauthable? %>

--- a/app/views/devise/shared/_links.html.erb
+++ b/app/views/devise/shared/_links.html.erb
@@ -1,23 +1,26 @@
 
     <%- if controller_name != 'sessions' %>
-  <%= link_to "Log In", new_session_path(resource_name), class: "btn logbutton"  %><br />
-<% end -%>
+    Do you already have an account? <%= link_to "Log in now »", new_session_path(resource_name)  %><br>
+    <% end -%>
+
+    <%- if controller_name = 'sessions' %>
+    New to Find My Flock? <%= link_to "Sign up now »", new_registration_registration_path  %><br>
+    <% end -%>
+
+
 
 <%- if devise_mapping.omniauthable? %>
   <%- resource_class.omniauth_providers.each do |provider| %>
-    <%= link_to "Sign in with #{OmniAuth::Utils.camelize(provider)}", omniauth_authorize_path(resource_name, provider), class: "btn linkedin logbutton" %><br />
+    You have a LinkedIn account? <%= link_to "Connect with #{OmniAuth::Utils.camelize(provider)} »", omniauth_authorize_path(resource_name, provider) %><br />
   <% end -%>
 
-<%- if devise_mapping.recoverable? && controller_name != 'passwords' && controller_name != 'registrations' %>
-  <%= link_to "Forgot your password?", new_password_path(resource_name), class: "btn logbutton"  %><br />
-<% end -%>
 
 <%- if devise_mapping.confirmable? && controller_name != 'confirmations' %>
-  <%= link_to "Didn't receive confirmation instructions?", new_confirmation_path(resource_name), class: "btn logbutton"  %><br />
+  <%= link_to "Didn't receive confirmation instructions?", new_confirmation_path(resource_name) %><br />
 <% end -%>
 
 <%- if devise_mapping.lockable? && resource_class.unlock_strategy_enabled?(:email) && controller_name != 'unlocks' %>
-  <%= link_to "Didn't receive unlock instructions?", new_unlock_path(resource_name), class: "btn logbutton"  %><br />
+  <%= link_to "Didn't receive unlock instructions?", new_unlock_path(resource_name)  %><br />
 <% end -%>
 
 

--- a/config/initializers/simple_form.rb
+++ b/config/initializers/simple_form.rb
@@ -167,4 +167,5 @@ SimpleForm.setup do |config|
 
   # Defines which i18n scope will be used in Simple Form.
   # config.i18n_scope = 'simple_form'
+  config.label_text = lambda { |label, required, explicit_label| "#{label}" }
 end

--- a/config/initializers/simple_form.rb
+++ b/config/initializers/simple_form.rb
@@ -167,5 +167,7 @@ SimpleForm.setup do |config|
 
   # Defines which i18n scope will be used in Simple Form.
   # config.i18n_scope = 'simple_form'
+
+  # Removes the asterisk in front of the required label fields.
   config.label_text = lambda { |label, required, explicit_label| "#{label}" }
 end


### PR DESCRIPTION
I followed the example of the Log In page found on Twitter. I used it for the following paths:
- Sessions > New
- Registrations > New
- Registrations > Edit
- Password > New

Works like a charm locally but, as usual, tests to break it and QA to make it perfect 😊 

To be noted for later: the following pages "Confirmations > News", "Unlocks > New" and "Passwords > Edit" couldn't be found.
The password and email address can however be edited in "Registrations > Edit" (but a link need to be added somewhere in the profile - I added the ticket in Trello in the Backlog).